### PR TITLE
Remove unimplemented version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	showVersion = flag.Bool("version", false, "Print version information.")
-	configFile  = flag.String(
+	configFile = flag.String(
 		"config.file", "ipmi.yml",
 		"Path to configuration file.",
 	)


### PR DESCRIPTION
This was a leftover from when the exporter used more of the Prometheus
build tooling, which was eventually deemed overkill for such a small
project (at least until it has matured a bit).

There is currently no versioning of any significance anyways, so remove
it for now.

This fixes #15.